### PR TITLE
fix: bucket eviction check was executed 1000 times more often than required

### DIFF
--- a/src/cache_bucket.erl
+++ b/src/cache_bucket.erl
@@ -79,7 +79,7 @@ init([], Opts, State) ->
    TTL  = proplists:get_value(ttl,    Opts, ?DEF_CACHE_TTL),
    Size = proplists:get_value(size,   Opts),
    Mem  = proplists:get_value(memory, Opts),
-   Evict= cache_util:mdiv(TTL,  State#cache.n),
+   Evict= cache_util:mdiv(TTL,  State#cache.n) * 1000,
    Heap = cache_heap:new(
       Type
      ,cache_util:mdiv(TTL,  State#cache.n)


### PR DESCRIPTION
Seconds instead of milliseconds were passed to erlang:send_after.
There are two identical functions that check buckets: check_heap and evict_heap. Seems like evict should be enough to do the job, why use another check at different intervals?