### PR TITLE
Explicit cache segments allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Use `cache:start_link(...)` to spawn an new cache instance. It supports a config
 The library implements traditional key/value interface through `put`, `get` and `remove` functions. The function `get` prolongs ttl of the item, use `lookup` to keep ttl untouched.
 
 ```erlang
-   application:start(cache).
-   {ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
-   
-   ok  = cache:put(my_cache, <<"my key">>, <<"my value">>).
-   Val = cache:get(my_cache, <<"my key">>).
+application:start(cache).
+{ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
+
+ok  = cache:put(my_cache, <<"my key">>, <<"my value">>).
+Val = cache:get(my_cache, <<"my key">>).
 ```
 
 
@@ -83,11 +83,11 @@ The library implements traditional key/value interface through `put`, `get` and 
 The library provides synchronous and asynchronous implementation of same functions. The asynchronous variant of function is annotated with `_` suffix. E.g. `get(...)` is a synchronous cache lookup operation (the process is blocked until cache returns); `get_(...)` is an asynchronous variant that delivers result of execution to mailbox.
 
 ```erlang
-   application:start(cache).
-   {ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
+application:start(cache).
+{ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
 
-   Ref = cache:get_(my_cache, <<"my key">>).
-   receive {Ref, Val} -> Val end.
+Ref = cache:get_(my_cache, <<"my key">>).
+receive {Ref, Val} -> Val end.
 ```
 
 ### transform element
@@ -95,35 +95,35 @@ The library provides synchronous and asynchronous implementation of same functio
 The library allows to read-and-modify (modify in-place) cached element. You can `apply` any function over cached elements.
 
 ```erlang
-   application:start(cache).
-   {ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
+application:start(cache).
+{ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
 
-   cache:put(my_cache, <<"my key">>, <<"x">>).
-   cache:apply(my_cache, <<"my key">>, fun(X) -> <<"x", X/binary>> end).
-   cache:get(my_cache, <<"my key">>).
+cache:put(my_cache, <<"my key">>, <<"x">>).
+cache:apply(my_cache, <<"my key">>, fun(X) -> <<"x", X/binary>> end).
+cache:get(my_cache, <<"my key">>).
 ```
 
 The library implement helper functions to transform elements with `append` or `prepend`.
 
 ```erlang
-   application:start(cache).
-   {ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
+application:start(cache).
+{ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
 
-   cache:put(my_cache, <<"my key">>, <<"b">>).
-   cache:append(my_cache, <<"my key">>, <<"c">>).
-   cache:prepend(my_cache, <<"my key">>, <<"a">>).
-   cache:get(my_cache, <<"my key">>).
+cache:put(my_cache, <<"my key">>, <<"b">>).
+cache:append(my_cache, <<"my key">>, <<"c">>).
+cache:prepend(my_cache, <<"my key">>, <<"a">>).
+cache:get(my_cache, <<"my key">>).
 ```
 
 ### accumulator
 
 ```erlang
-   application:start(cache).
-   {ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
+application:start(cache).
+{ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
 
-   cache:acc(my_cache, <<"my key">>, 1).
-   cache:acc(my_cache, <<"my key">>, 1).
-   cache:acc(my_cache, <<"my key">>, 1).
+cache:acc(my_cache, <<"my key">>, 1).
+cache:acc(my_cache, <<"my key">>, 1).
+cache:acc(my_cache, <<"my key">>, 1).
 ```
 
 ### check-and-store
@@ -152,25 +152,25 @@ Therefore, frequent read/write of large entries might impact on overall Erlang p
 
 The global cache instance is visible to all Erlang nodes in the cluster.
 ```erlang
-   %% at a@example.com
-   {ok, _} = cache:start_link({global, my_cache}, [{n, 10}, {ttl, 60}]).
-   Val = cache:get({global, my_cache}, <<"my key">>).
-   
-   %% at b@example.com
-   ok  = cache:put({global, my_cache}, <<"my key">>, <<"my value">>).
-   Val = cache:get({global, my_cache}, <<"my key">>).
+%% at a@example.com
+{ok, _} = cache:start_link({global, my_cache}, [{n, 10}, {ttl, 60}]).
+Val = cache:get({global, my_cache}, <<"my key">>).
+
+%% at b@example.com
+ok  = cache:put({global, my_cache}, <<"my key">>, <<"my value">>).
+Val = cache:get({global, my_cache}, <<"my key">>).
 ```
 
 The local cache instance is accessible for any Erlang nodes in the cluster. 
 
 ```erlang
-   %% a@example.com
-   {ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
-   Val = cache:get(my_cache, <<"my key">>).
-   
-   %% b@example.com
-   ok  = cache:put({my_cache, 'a@example.com'}, <<"my key">>, <<"my value">>).
-   Val = cache:get({my_cache, 'a@example.com'}, <<"my key">>).
+%% a@example.com
+{ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
+Val = cache:get(my_cache, <<"my key">>).
+
+%% b@example.com
+ok  = cache:put({my_cache, 'a@example.com'}, <<"my key">>, <<"my value">>).
+Val = cache:get({my_cache, 'a@example.com'}, <<"my key">>).
 ```
 
 
@@ -179,17 +179,17 @@ The local cache instance is accessible for any Erlang nodes in the cluster.
 Module `cache_shards` provides simple sharding on top of `cache`. It uses simple `hash(Key) rem NumShards` approach, and keeps `NumShards` in application environment. This feature is still **experimental**, its interface is a subject to change in further releases. 
 
 ```erlang
-   {ok, _} = cache_shards:start_link(my_cache, 8, [{n, 10}, {ttl, 60}]).
-   ok = cache_shards:put(my_cache, key1, "Hello").
-   {ok,"Hello"} = cache_shards:get(my_cache, key1).
+{ok, _} = cache_shards:start_link(my_cache, 8, [{n, 10}, {ttl, 60}]).
+ok = cache_shards:put(my_cache, key1, "Hello").
+{ok,"Hello"} = cache_shards:get(my_cache, key1).
 ```
 
 `sharded_cache` uses only small subset of `cache` API. But you can get shard name for your key and then use `cache` directly.
 ```erlang
-   {ok, Shard} = cache_shards:get_shard(my_cache, key1)
-   {ok, my_cache_2}
-   cache:lookup(Shard, key1).
-   "Hello"
+{ok, Shard} = cache_shards:get_shard(my_cache, key1)
+{ok, my_cache_2}
+cache:lookup(Shard, key1).
+"Hello"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -11,20 +11,26 @@ Library implements segmented in-memory cache.
 
 Cache uses N disposable ETS tables instead of single one. The cache applies eviction and quota
 policies at segment level. The oldest ETS table is destroyed and new one is created when 
-quota or TTL criteria are exceeded. This approach outperforms the traditional timestamp indexing techniques.    
+quota or TTL criteria are exceeded. This approach outperforms the traditional timestamp indexing techniques.
 
 The write operation always uses youngest segment. The read operation lookup key from youngest to oldest table until it is found same time key is moved to youngest segment to prolong TTL. If none of ETS table contains key then cache-miss occurs. 
 
 The downside is inability to assign precise TTL per single cache entry. TTL is always approximated to nearest segment. (e.g. cache with 60 sec TTL and 10 segments has 6 sec accuracy on TTL) 
+
+## Key features
+
+* Key/value interface to read/write cached entities
+* Naive transform interface (accumulators, lists, binaries) to modify entities in-place
+* Check-and-store of put behavior
+* Supports asynchronous I/O to cache buckets
+* Sharding of cache bucket
 
 
 ## Getting started
 
 The latest version of the library is available at its `master` branch. All development, including new features and bug fixes, take place on the `master` branch using forking and pull requests as described in contribution guidelines.
 
-### Installation
-
-If you are using `rebar3` you can include the library in your project with
+The stable library release is available via hex packages, add the library as dependency to `rebar.config`
 
 ```erlang
 {deps, [
@@ -36,7 +42,7 @@ If you are using `rebar3` you can include the library in your project with
 ### Usage
 
 The library exposes public primary interface through exports of module [`cache.erl`](src/cache.erl).
-An experimental features are available through following interfaces. Please note that further releases of library would promote experimental features to [primary interface](src/cache.erl).
+An experimental features are available through interface extensions. Please note that further releases of library would promote experimental features to [primary interface](src/cache.erl).
 * [`sharded_cache.erl`](src/cache_shards.erl)
 
 Build library and run the development console to evaluate key features
@@ -45,19 +51,23 @@ Build library and run the development console to evaluate key features
 make && make run
 ```
 
+### spawn and configure
 
-## Key features
-
-* Key/value interface to read/write cached entities
-* Naive transform interface (accumulators, lists, binaries) to modify entities in-place
-* Check-and-store of put behavior
-* Supports asynchronous I/O to cache buckets
-* Sharding of cache bucket
+Use `cache:start_link(...)` to spawn an new cache instance. It supports a configuration using property lists:
+* `type` - a type of ETS table to used as segment, default is `set`. See `ets:new/2` documentation for supported values. 
+* `n` - number of cache segments, default is 10.
+* `ttl` - time to live of cached items in seconds, default is 600 seconds. It is recommended to use value multiple to `n`. The oldest cache segment is evicted every `ttl / n` seconds. 
+* `size` - number of items to store in cache. It is recommended to use value multiple to `n`, each cache segment takes about `size / n` items. The size policy is applied only to youngest segment.
+* `memory` - rough number of bytes available for cache items. Each cache segment is allowed to take about `memory / n` bytes. Note: policy enforcement accounts Erlang word size.
+* `policy` - cache eviction policy, default is `lru`, supported values are Least Recently Used `lru`, Most Recently Used `mru`.
+* `check` - time in seconds to enforce cache policy. The default behavior enforces policy every `ttl / n` seconds. This timeout helps to optimize size/memory policy enforcement at high throughput system. The timeout is disabled by default. 
+* `stats` - cache statistics handler either function/2 or `{M, F}` struct.
+* `heir` - the ownership of ETS segment is given away to the process during segment eviction. See `ets:give_away/3` for details.  
 
 
 ### key/value interface
 
-The library implements traditional key/value interface through `put`, `get` and `remove` functions.
+The library implements traditional key/value interface through `put`, `get` and `remove` functions. The function `get` prolongs ttl of the item, use `lookup` to keep ttl untouched.
 
 ```erlang
    application:start(cache).
@@ -187,11 +197,14 @@ Module `cache_shards` provides simple sharding on top of `cache`. It uses simple
 
 The library is Apache 2.0 licensed and accepts contributions via GitHub pull requests.
 
-### getting started
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
 
-* Fork the repository on GitHub
-* Read the README.md for build instructions
-* Make pull request
+The development requires [Erlang/OTP](http://www.erlang.org/downloads) version 19.0 or later and essential build tools.
+
 
 ### commit message
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The cache instances are configurable via `sys.config`. Theses cache instances ar
 
 ```erlang
 {cache, [
-	{my_cache, [{n, 10}, {ttl, 60}]}
+   {my_cache, [{n, 10}, {ttl, 60}]}
 ]}
 ```
 
@@ -164,7 +164,7 @@ The global cache instance is visible to all Erlang nodes in the cluster.
 The local cache instance is accessible for any Erlang nodes in the cluster. 
 
 ```erlang
-	%% a@example.com
+   %% a@example.com
    {ok, _} = cache:start_link(my_cache, [{n, 10}, {ttl, 60}]).
    Val = cache:get(my_cache, <<"my key">>).
    

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
-{cover_enabled, true}.
+{erl_opts, [
+   warnings_as_errors
+]}.
 
 {deps, []}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,14 @@
 
 {deps, []}.
 
+{profiles, [
+   {test, [
+      {deps, [
+         meck
+      ]}
+   ]}
+]}.
+
 %%
 %%
 {plugins                , [coveralls]}.

--- a/src/cache_bucket.erl
+++ b/src/cache_bucket.erl
@@ -82,6 +82,7 @@ init([], Opts, State) ->
    Evict= cache_util:mmul(cache_util:mdiv(TTL,  State#cache.n), 1000),
    Heap = cache_heap:new(
       Type
+     ,State#cache.n
      ,cache_util:mdiv(TTL,  State#cache.n)
      ,cache_util:mdiv(Size, State#cache.n)
      ,cache_util:mdiv(cache_util:mdiv(Mem,  State#cache.n), erlang:system_info(wordsize))

--- a/src/cache_bucket.erl
+++ b/src/cache_bucket.erl
@@ -148,7 +148,7 @@ handle_call(i, _, State) ->
 
 handle_call({heap, N}, _, State) ->
    try
-      {_, Ref} = lists:nth(N, lists:reverse(cache_heap:refs(State#cache.heap))),
+      {_, Ref} = lists:nth(N, cache_heap:refs(State#cache.heap)),
       {reply, Ref, State}
    catch _:_ ->
       {reply, badarg, State}

--- a/src/cache_bucket.erl
+++ b/src/cache_bucket.erl
@@ -37,7 +37,7 @@
    name   = undefined         :: atom()     %% name of cache bucket
   ,heap   = undefined         :: list()     %% cache heap segments
   ,n      = ?DEF_CACHE_N      :: integer()  %% number of segments
-  ,policy = ?DEF_CACHE_POLICY :: integer()  %% eviction policy
+  ,policy = ?DEF_CACHE_POLICY :: atom()     %% eviction policy
   ,check  = ?DEF_CACHE_CHECK  :: integer()  %% status check timeout
   ,evict  = undefined         :: integer()  %% evict timeout
   ,stats  = undefined         :: any()      %% stats aggregation functor 
@@ -74,27 +74,21 @@ init([{heir,   X} | Tail], Opts, State) ->
    init(Tail, Opts, State#cache{heir=X});
 init([_ | Tail], Opts, State) ->
    init(Tail, Opts, State);
-init([], Opts, State) ->
+init([], Opts, #cache{n = N, check = Check} = State) ->
    Type = proplists:get_value(type,   Opts, ?DEF_CACHE_TYPE),
    TTL  = proplists:get_value(ttl,    Opts, ?DEF_CACHE_TTL),
    Size = proplists:get_value(size,   Opts),
    Mem  = proplists:get_value(memory, Opts),
-   Evict= cache_util:mmul(cache_util:mdiv(TTL,  State#cache.n), 1000),
-   Heap = cache_heap:new(
-      Type
-     ,State#cache.n
-     ,cache_util:mdiv(TTL,  State#cache.n)
-     ,cache_util:mdiv(Size, State#cache.n)
-     ,cache_util:mdiv(cache_util:mdiv(Mem,  State#cache.n), erlang:system_info(wordsize))
-   ),
-   (catch erlang:send_after(State#cache.check, self(), check_heap)),
+   Evict= cache_util:mmul(cache_util:mdiv(TTL,  N), 1000),
+   Heap = cache_heap:new(Type, N, TTL, Size, Mem),
+   (catch erlang:send_after(Check, self(), check_heap)),
    (catch erlang:send_after(Evict, self(), evict_heap)),
    State#cache{heap=Heap, evict=Evict}.
 
 %%
 %%     
-terminate(_Reason, State) ->
-   cache_heap:purge(State#cache.heap, State#cache.heir),
+terminate(_Reason, #cache{heir = Heir, heap = Heap}) ->
+   cache_heap:purge(Heir, Heap),
    ok.
 
 
@@ -156,7 +150,7 @@ handle_call(i, _, State) ->
 
 handle_call({heap, N}, _, State) ->
    try
-      {_, Ref} = lists:nth(N, cache_heap:refs(State#cache.heap)),
+      {_, Ref} = lists:nth(N, lists:reverse(cache_heap:refs(State#cache.heap))),
       {reply, Ref, State}
    catch _:_ ->
       {reply, badarg, State}
@@ -165,8 +159,12 @@ handle_call({heap, N}, _, State) ->
 handle_call(drop, _, State) ->
    {stop, normal, ok, State};
 
-handle_call(purge, _, State) ->
-   {reply, ok, State#cache{heap=cache_heap:purge(State#cache.heap, State#cache.heir)}};
+handle_call(purge, _, #cache{heir = Heir, heap = Heap} = State) ->
+   {reply, ok,
+      State#cache{
+         heap = cache_heap:purge(Heir, Heap)
+      }
+   };
 
 handle_call(_, _, State) ->
    {noreply, State}.
@@ -204,26 +202,25 @@ handle_cast(_, State) ->
 
 %%
 %%
-handle_info(check_heap, #cache{n=N, check=Check}=State) ->
+handle_info(check_heap, #cache{check = Check, heir = Heir, heap = Heap0} = State) ->
    erlang:send_after(Check, self(), check_heap),
-   {Reason, Heap} = cache_heap:slip(State#cache.heap),
-   case cache_heap:size(Heap) of
-      X when X > N ->
+   case cache_heap:slip(Heir, Heap0) of
+      {ok, Heap1} ->
+         {noreply, State#cache{heap = Heap1}};
+      {Reason, Heap1} ->
          cache_util:stats(State#cache.stats, {cache, State#cache.name, Reason}),
-         {noreply, State#cache{heap=cache_heap:drop(Heap, State#cache.heir)}};
-      _ ->
-         {noreply, State#cache{heap=Heap}}
+         {noreply, State#cache{heap = Heap1}}
    end;
 
-handle_info(evict_heap, #cache{n=N, evict=Evict}=State) ->
+
+handle_info(evict_heap, #cache{evict = Evict, heir = Heir, heap = Heap0} = State) ->
    erlang:send_after(Evict, self(), evict_heap),
-   {Reason, Heap} = cache_heap:slip(State#cache.heap),
-   case cache_heap:size(Heap) of
-      X when X > N ->
+   case cache_heap:slip(Heir, Heap0) of
+      {ok, Heap1} ->
+         {noreply, State#cache{heap = Heap1}};
+      {Reason, Heap1} ->
          cache_util:stats(State#cache.stats, {cache, State#cache.name, Reason}),
-         {noreply, State#cache{heap=cache_heap:drop(Heap, State#cache.heir)}};
-      _ ->
-         {noreply, State#cache{heap=Heap}}
+         {noreply, State#cache{heap = Heap1}}
    end;
 
 handle_info(_, S) ->
@@ -242,40 +239,33 @@ code_change(_Vsn, S, _Extra) ->
 
 %%
 %% insert value to cache
-cache_put(Key, Val, undefined, #cache{name=_Name, heap=Heap}=State) ->
-   {_, Head} = cache_heap:head(Heap),
+cache_put(Key, Val, undefined, #cache{name = _Name, heap = Heap} = State) ->
+   {{_, Head}, Tail} = cache_heap:split(Heap),
    true = ets:insert(Head, {Key, Val}),
-   ok   = heap_remove(Key, cache_heap:tail(Heap)),
+   ok   = heap_remove(Key, Tail),
    _    = stats(put, State),
    ?DEBUG("cache ~p: put ~p to heap ~p~n", [_Name, Key, Head]),
    State;
 
-cache_put(Key, Val, TTL, #cache{name=_Name, heap=Heap}=State) ->
-   Expire = cache_util:now() + TTL,
-   Refs   = cache_heap:refs(Heap),
-   case lists:splitwith(fun({X, _}) -> X > Expire end, Refs) of
-      {[],  _Tail} ->
-         cache_put(Key, Val, undefined, State);
-      {Head, Tail} ->
-         [{_, Inst} | Rest] = lists:reverse(Head),
-         true = ets:insert(Inst, {Key, Val}),
-         ok   = heap_remove(Key, Rest ++ Tail),
-         _    = stats(put, State),
-         ?DEBUG("cache ~p: put ~p to heap ~p~n", [_Name, Key, Inst]),
-         State
-   end.
+cache_put(Key, Val, TTL, #cache{name = _Name, heap = Heap} = State) ->
+   {{_, Head}, Tail} = cache_heap:split(cache_util:now() + TTL, Heap),
+   true = ets:insert(Head, {Key, Val}),
+   ok   = heap_remove(Key, Tail),
+   _    = stats(put, State),
+   ?DEBUG("cache ~p: put ~p to heap ~p~n", [_Name, Key, Head]),
+   State.
 
 %%
 %% get cache value
-cache_get(Key, #cache{policy=mru}=State) ->
+cache_get(Key, #cache{policy = mru} = State) ->
    % cache MRU should not move key anywhere because
    % cache always evicts last generation
    % fall-back to cache lookup
    cache_lookup(Key, State);
 
-cache_get(Key, #cache{name=_Name, heap=Heap}=State) ->
-   {_, Head} = cache_heap:head(Heap),
-   case heap_lookup(Key, cache_heap:refs(Heap)) of
+cache_get(Key, #cache{name = _Name, heap = Heap} = State) ->
+   {{_, Head}, Tail} = cache_heap:split(Heap),
+   case heap_lookup(Key, Head, Tail) of
       undefined   ->
          stats(miss, State),
          undefined;
@@ -293,8 +283,9 @@ cache_get(Key, #cache{name=_Name, heap=Heap}=State) ->
 
 %%
 %% lookup cache value
-cache_lookup(Key, #cache{name=_Name, heap=Heap}=State) ->
-   case heap_lookup(Key, cache_heap:refs(Heap)) of
+cache_lookup(Key, #cache{name = _Name, heap = Heap} = State) ->
+   {{_, Head}, Tail} = cache_heap:split(Heap),
+   case heap_lookup(Key, Head, Tail) of
       undefined    ->
          stats(miss, State),
          undefined;
@@ -307,7 +298,8 @@ cache_lookup(Key, #cache{name=_Name, heap=Heap}=State) ->
 %%
 %% check if key exists
 cache_has(Key, #cache{name=_Name, heap=Heap}) ->
-   case heap_has(Key, cache_heap:refs(Heap)) of
+   {Head, Tail} = cache_heap:split(Heap),
+   case heap_has(Key, Head, Tail) of
       false  ->
          false;
       _Heap  ->
@@ -317,8 +309,9 @@ cache_has(Key, #cache{name=_Name, heap=Heap}) ->
 
 %%
 %% check key ttl
-cache_ttl(Key,#cache{heap=Heap}) ->
-   case heap_has(Key, cache_heap:refs(Heap)) of
+cache_ttl(Key,#cache{heap = Heap}) ->
+   {Head, Tail} = cache_heap:split(Heap),
+   case heap_has(Key,  Head, Tail) of
       false       ->
          undefined;
       {Expire, _} ->
@@ -327,8 +320,9 @@ cache_ttl(Key,#cache{heap=Heap}) ->
 
 %%
 %%
-cache_remove(Key, #cache{name=_Name, heap=Heap}=State) ->
-   ok = heap_remove(Key, cache_heap:refs(Heap)),
+cache_remove(Key, #cache{name = _Name, heap = Heap} = State) ->
+   {{_, Head}, Tail} = cache_heap:split(Heap),
+   ok = heap_remove(Key, Head, Tail),
    _  = stats(remove, State),
    ?DEBUG("cache ~p: remove ~p~n", [_Name, Key]),
    State.
@@ -426,6 +420,14 @@ cache_append(Key, Val, State) ->
 
 %%
 %% remove key from heap segments
+heap_remove(Key, Heap, Tail) ->
+   ets:delete(Heap, Key),
+   heap_remove(Key, Tail).
+
+heap_remove(Key, {Tail, Head}) ->
+   heap_remove(Key, Tail),
+   heap_remove(Key, Head);
+
 heap_remove(Key, Heap) ->
    lists:foreach(
       fun({_, Id}) -> ets:delete(Id, Key) end, 
@@ -434,6 +436,20 @@ heap_remove(Key, Heap) ->
 
 %%
 %%
+heap_lookup(Key, Heap, Tail) ->
+   case ets:lookup(Heap, Key) of
+      []         -> heap_lookup(Key, Tail);
+      [{_, Val}] -> {Heap, Val}
+   end.
+
+heap_lookup(Key, {Tail, Head}) ->
+   case heap_lookup(Key, Tail) of
+      undefined ->
+         heap_lookup(Key, Head);
+      Hit ->
+         Hit
+   end;
+
 heap_lookup(Key, [{_, Heap} | Tail]) ->
    case ets:lookup(Heap, Key) of
       []         -> heap_lookup(Key, Tail);
@@ -445,7 +461,21 @@ heap_lookup(_Key, []) ->
 
 %%
 %%
-heap_has(Key, [{_, Heap}=X | Tail]) ->
+heap_has(Key, {_, Heap} = X, Tail) ->
+   case ets:lookup(Heap, Key) of
+      []         -> heap_has(Key, Tail);
+      [{_, Val}] -> X
+   end.
+
+heap_has(Key, {Tail, Head}) ->
+   case heap_has(Key, Tail) of
+      false ->
+         heap_has(Key, Head);
+      Hit   ->
+         Hit
+   end;
+
+heap_has(Key, [{_, Heap} = X | Tail]) ->
    case ets:member(Heap, Key) of
       false  -> heap_has(Key, Tail);
       true   -> X

--- a/src/cache_bucket.erl
+++ b/src/cache_bucket.erl
@@ -36,7 +36,6 @@
 -record(cache, {
    name   = undefined         :: atom()     %% name of cache bucket
   ,heap   = undefined         :: list()     %% cache heap segments
-  ,n      = ?DEF_CACHE_N      :: integer()  %% number of segments
   ,policy = ?DEF_CACHE_POLICY :: atom()     %% eviction policy
   ,check  = ?DEF_CACHE_CHECK  :: integer()  %% status check timeout
   ,evict  = undefined         :: integer()  %% evict timeout
@@ -64,8 +63,6 @@ init([Name, Opts]) ->
 
 init([{policy, X} | Tail], Opts, State) ->
    init(Tail, Opts, State#cache{policy=X});
-init([{n,      X} | Tail], Opts, State) ->
-   init(Tail, Opts, State#cache{n=X});
 init([{check,  X} | Tail], Opts, State) ->
    init(Tail, Opts, State#cache{check=X * 1000});
 init([{stats,  X} | Tail], Opts, State) ->
@@ -74,7 +71,8 @@ init([{heir,   X} | Tail], Opts, State) ->
    init(Tail, Opts, State#cache{heir=X});
 init([_ | Tail], Opts, State) ->
    init(Tail, Opts, State);
-init([], Opts, #cache{n = N, check = Check} = State) ->
+init([], Opts, #cache{check = Check} = State) ->
+   N    = proplists:get_value(n,      Opts, ?DEF_CACHE_N),
    Type = proplists:get_value(type,   Opts, ?DEF_CACHE_TYPE),
    TTL  = proplists:get_value(ttl,    Opts, ?DEF_CACHE_TTL),
    Size = proplists:get_value(size,   Opts),
@@ -463,8 +461,8 @@ heap_lookup(_Key, []) ->
 %%
 heap_has(Key, {_, Heap} = X, Tail) ->
    case ets:lookup(Heap, Key) of
-      []         -> heap_has(Key, Tail);
-      [{_, Val}] -> X
+      []       -> heap_has(Key, Tail);
+      [{_, _}] -> X
    end.
 
 heap_has(Key, {Tail, Head}) ->

--- a/src/cache_heap.erl
+++ b/src/cache_heap.erl
@@ -101,7 +101,7 @@ split(Expire, #heap{segments = {Tail, Head}} = Heap) ->
             {A, [Segment | B]} -> 
                {Segment, {Tail, A ++ B}}
          end;
-      {[], B} ->
+      {[], _} ->
          split(Heap);
       {A,  B} ->
          [Segment | Ax] = lists:reverse(A),

--- a/src/cache_heap.erl
+++ b/src/cache_heap.erl
@@ -29,13 +29,12 @@
 ]).   
 
 %%
-%% heap
 -record(heap, {
-   type        = set       :: atom(),      %% type of segment
-   ttl         = undefined :: integer(),   %% segment expire time
-   cardinality = undefined :: integer(),   %% segment cardinality quota
-   memory      = undefined :: integer(),   %% segment memory quota
-   segments    = []        :: [integer()]  %% segment references 
+   type        = set       :: atom()       %% type of segment
+,  ttl         = undefined :: integer()    %% segment expire time
+,  cardinality = undefined :: integer()    %% segment cardinality quota
+,  memory      = undefined :: integer()    %% segment memory quota
+,  segments    = []        :: [integer()]  %% segment references 
 }).
 
 %%

--- a/src/cache_heap.erl
+++ b/src/cache_heap.erl
@@ -19,13 +19,13 @@
 
 -export([
    new/4
-  ,size/1
-  ,head/1
-  ,tail/1
-  ,refs/1
-  ,slip/1
-  ,drop/2
-  ,purge/2
+,  size/1
+,  head/1
+,  tail/1
+,  refs/1
+,  slip/1
+,  drop/2
+,  purge/2
 ]).   
 
 %%
@@ -45,9 +45,9 @@
 new(Type, TTL, Cardinality, Memory) ->
    init(#heap{
       type        = Type
-     ,ttl         = TTL
-     ,cardinality = Cardinality
-     ,memory      = Memory
+   ,  ttl         = TTL
+   ,  cardinality = Cardinality
+   ,  memory      = Memory
    }).
 
 %%

--- a/src/cache_heap.erl
+++ b/src/cache_heap.erl
@@ -19,23 +19,25 @@
 
 -export([
    new/5
-,  size/1
-,  head/1
-,  tail/1
 ,  refs/1
-,  slip/1
-,  drop/2
+,  split/1
+,  split/2
+,  slip/2
 ,  purge/2
 ]).   
 
 %%
+-type segment() :: [{integer(), reference()}].
+-type heir()    :: undefined | atom() | pid().
+-type queue()   :: {[segment()], [segment()]}.
+
 -record(heap, {
    type        = set       :: atom()       %% type of segment
 ,  n           = undefined :: integer()    %% number of segments
 ,  ttl         = undefined :: integer()    %% segment expire time
 ,  cardinality = undefined :: integer()    %% segment cardinality quota
 ,  memory      = undefined :: integer()    %% segment memory quota
-,  segments    = []        :: [integer()]  %% segment references 
+,  segments    = undefined :: queue()      %% segment references
 }).
 
 %%
@@ -46,54 +48,85 @@ new(Type, N, TTL, Cardinality, Memory) ->
    init(#heap{
       type        = Type
    ,  n           = N
-   ,  ttl         = TTL
-   ,  cardinality = Cardinality
-   ,  memory      = Memory
+   ,  ttl         = TTL div N
+   ,  cardinality = cache_util:mdiv(Cardinality, N)
+   ,  memory      = cache_util:mdiv(cache_util:mdiv(Memory,  N), erlang:system_info(wordsize))
    }).
 
-%%
-%% return size of heap (number of segments)
--spec(size(#heap{}) -> integer()).
-
-size(#heap{segments=List}) ->
-   length(List).
-
-%%
-%% return head
--spec(head(#heap{}) -> {integer(), integer()}).
-
-head(#heap{segments=[Head | _]}) ->
-   Head.
+init(#heap{type = Type, n = N, ttl = TTL} = Heap) ->
+   T = cache_util:now(),
+   Segments = lists:map(
+      fun(Expire) ->
+         Ref = ets:new(undefined, [Type, protected]),
+         {T + Expire, Ref}
+      end,
+      lists:seq(TTL, N * TTL, TTL)
+   ),
+   Heap#heap{segments = queue:from_list(Segments)}.
 
 %%
-%% return tail
--spec(tail(#heap{}) -> [{integer(), integer()}]).
+%%
+-spec refs(#heap{}) -> [segment()].
 
-tail(#heap{segments=[_ | Tail]}) ->
-   Tail.
+refs(#heap{segments = Segments}) ->
+   queue:to_list(Segments).
 
 %%
-%% return reference to all segments
--spec(refs(#heap{}) -> [{integer(), integer()}]).
+%% split heap to writable segment and others
+-spec split(#heap{}) -> {segment(), queue()}.
 
-refs(#heap{segments=Refs}) ->
-   Refs.
+split(#heap{segments = Segments}) ->
+   {{value, Head}, Tail} = queue:out_r(Segments),
+   {Head, Tail}.
+
+
+-spec split(_, #heap{}) -> {segment(), queue()}.
+
+split(Expire, #heap{segments = {Tail, Head}} = Heap) ->
+   case 
+      lists:splitwith(
+         fun({T, _}) -> T > Expire end,
+         Tail
+      )
+   of
+      {_, []} ->
+         case
+            lists:splitwith(
+               fun({T, _}) -> T < Expire end,
+               Head
+            )
+         of
+            {[Segment | A], []} ->
+               {Segment, {Tail, A}};
+            {A, [Segment | B]} -> 
+               {Segment, {Tail, A ++ B}}
+         end;
+      {[], B} ->
+         split(Heap);
+      {A,  B} ->
+         [Segment | Ax] = lists:reverse(A),
+         {Segment, {lists:reverse(Ax) ++ B, Head}}
+   end.
+
 
 %%
 %% slip heap segments and report reason
--spec(slip(#heap{}) -> {ok | ttl | oom | ooc , #heap{}}).
+-spec slip(heir(), #heap{}) -> {ok | ttl | oom | ooc , #heap{}}.
 
-slip(#heap{}=Heap) ->
+slip(Heir, #heap{} = Heap) ->
    case is_expired(cache_util:now(), Heap) of
       false  ->
          {ok, Heap};
       Reason ->
-         {Reason, init(Heap)}
+         {Reason,
+            heap_remove_segment(Heir, heap_create_segment(Heap))
+         }
    end.
 
-is_expired(Time, #heap{cardinality=C, memory=M, segments=[{Expire, Ref}|_]}) ->
+is_expired(Time, #heap{cardinality = Card, memory = Mem, segments = Segments}) ->
+   {Expire, Ref} = queue:head(Segments),
    case 
-      {Time >= Expire, ets:info(Ref, size) >= C, ets:info(Ref, memory) >= M}
+      {Time >= Expire, ets:info(Ref, size) >= Card, ets:info(Ref, memory) >= Mem}
    of
       {true, _, _} -> ttl;
       {_, true, _} -> ooc;
@@ -101,37 +134,33 @@ is_expired(Time, #heap{cardinality=C, memory=M, segments=[{Expire, Ref}|_]}) ->
       _            -> false
    end.
 
-%%
-%% drop last segment 
--spec(drop(#heap{}, pid()) -> #heap{}).
+heap_create_segment(#heap{type = Type, ttl = TTL, segments = Segments} = Heap) ->
+   {LastTTL, _} = queue:last(Segments),
+   Ref    = ets:new(undefined, [Type, protected]),
+   Expire = TTL + LastTTL,
+   Heap#heap{segments = queue:in({Expire, Ref}, Segments)}.
 
-drop(#heap{segments=Segments}=Heap, Heir) ->
-   [{_, Ref}|T] = lists:reverse(Segments),
-   free(Heir, Ref),
-   Heap#heap{
-      segments = lists:reverse(T)
-   }.
+heap_remove_segment(Heir, #heap{segments = Segments} = Heap) ->
+   {{value, {_, Ref}}, T} = queue:out(Segments),
+   true = free(Heir, Ref),
+   Heap#heap{segments = T}.
 
 %%
 %% purge cache segments
--spec(purge(#heap{}, pid()) -> #heap{}).
+-spec purge(heir(), #heap{}) -> #heap{}.
 
-purge(#heap{segments=Segments}=Heap, Heir) ->
-   lists:foreach(fun({_, Ref}) -> free(Heir, Ref) end, Segments),
-   init(Heap#heap{segments=[]}).
-
-
-%%
-%% create heap segment
-init(#heap{segments=Segments}=Heap) ->
-   Ref    = ets:new(undefined, [Heap#heap.type, protected]),
-   Expire = cache_util:madd(Heap#heap.ttl,  cache_util:now()),
-   Heap#heap{segments = [{Expire, Ref} | Segments]}.
+purge(Heir, #heap{segments = Segments} = Heap) ->
+   lists:foreach(
+      fun({_, Ref}) -> true = free(Heir, Ref) end, 
+      queue:to_list(Segments)
+   ),
+   init(Heap#heap{segments = undefined}).
 
 %%
 %% destroy heap segment
 free(undefined, Ref) ->
    ets:delete(Ref);
+
 free(Heir, Ref)
  when is_pid(Heir) ->
    case erlang:is_process_alive(Heir) of
@@ -140,6 +169,7 @@ free(Heir, Ref)
       false ->
          ets:delete(Ref)
    end;
+
 free(Heir, Ref)
  when is_atom(Heir) ->
    case erlang:whereis(Heir) of

--- a/src/cache_heap.erl
+++ b/src/cache_heap.erl
@@ -18,7 +18,7 @@
 -module(cache_heap).
 
 -export([
-   new/4
+   new/5
 ,  size/1
 ,  head/1
 ,  tail/1
@@ -31,6 +31,7 @@
 %%
 -record(heap, {
    type        = set       :: atom()       %% type of segment
+,  n           = undefined :: integer()    %% number of segments
 ,  ttl         = undefined :: integer()    %% segment expire time
 ,  cardinality = undefined :: integer()    %% segment cardinality quota
 ,  memory      = undefined :: integer()    %% segment memory quota
@@ -39,11 +40,12 @@
 
 %%
 %% create new empty heap
--spec(new(atom(), integer(), integer(), integer()) -> #heap{}).
+-spec new(atom(), integer(), integer(), integer(), integer()) -> #heap{}.
 
-new(Type, TTL, Cardinality, Memory) ->
+new(Type, N, TTL, Cardinality, Memory) ->
    init(#heap{
       type        = Type
+   ,  n           = N
    ,  ttl         = TTL
    ,  cardinality = Cardinality
    ,  memory      = Memory

--- a/test/cache_SUITE.erl
+++ b/test/cache_SUITE.erl
@@ -85,6 +85,14 @@ evict_no_ttl(_Config) ->
    undefined = cache:lookup(Cache, key),
    ok = cache:drop(Cache).
 
+evict_ooc(_Config) ->
+   {ok, Cache} = cache:start_link([{n, 10}, {size, 20}, {check, 1}]),
+   ok = cache:put(Cache, key1, val),
+   ok = cache:put(Cache, key2, val),
+   [2 | _] = cache:i(Cache, size),
+   timer:sleep(1200),
+   [0, 2 | _] = cache:i(Cache, size),
+   ok = cache:drop(Cache).
 
 %%%----------------------------------------------------------------------------   
 %%%

--- a/test/cache_SUITE.erl
+++ b/test/cache_SUITE.erl
@@ -16,10 +16,8 @@
 -module(cache_SUITE).
 -include_lib("common_test/include/ct.hrl").
 
-%%
-%% common test
--export([all/0]).
 -compile(export_all).
+-compile(nowarn_export_all).
 
 all() ->
    [Test || {Test, NAry} <- ?MODULE:module_info(exports), 

--- a/test/cache_heap_SUITE.erl
+++ b/test/cache_heap_SUITE.erl
@@ -16,10 +16,8 @@
 -module(cache_heap_SUITE).
 -include_lib("common_test/include/ct.hrl").
 
-%%
-%% common test
--export([all/0, init_per_testcase/2, end_per_testcase/2]).
 -compile(export_all).
+-compile(nowarn_export_all).
 
 all() ->
    [Test || {Test, NAry} <- ?MODULE:module_info(exports), 

--- a/test/cache_heap_SUITE.erl
+++ b/test/cache_heap_SUITE.erl
@@ -43,32 +43,6 @@ heap_init(_) ->
    Expect = lists:seq(6, 60, 6),
    Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
 
-% %%
-% heap_size(_) ->
-%    Heap = cache_heap:new(set, 10, 60, 1000, 102400),
-%    10   = cache_heap:size(Heap).
-
-% %%
-% heap_heap(_) ->
-%    meck:new(cache_util, [passthrough]),
-%    meck:expect(cache_util, now, fun() -> 0 end),
-
-%    Heap = cache_heap:new(set, 10, 60, 1000, 102400),
-%    {6, _} = cache_heap:head(Heap),
-
-%    meck:unload(cache_util).
-
-% %%
-% heap_tail(_) ->
-%    meck:new(cache_util, [passthrough]),
-%    meck:expect(cache_util, now, fun() -> 0 end),
-
-%    Heap = cache_heap:new(set, 10, 60, 1000, 102400),
-%    Tail = cache_heap:tail(Heap),
-%    Expect = lists:seq(12, 60, 6),
-%    Expect = [Expire || {Expire, _} <- Tail],
-
-%    meck:unload(cache_util).
 
 %%
 heap_purge(_) ->

--- a/test/cache_heap_SUITE.erl
+++ b/test/cache_heap_SUITE.erl
@@ -1,0 +1,130 @@
+%%
+%%   Copyright 2015 Dmitry Kolesnikov, All Rights Reserved
+%%
+%%   Licensed under the Apache License, Version 2.0 (the "License");
+%%   you may not use this file except in compliance with the License.
+%%   You may obtain a copy of the License at
+%%
+%%       http://www.apache.org/licenses/LICENSE-2.0
+%%
+%%   Unless required by applicable law or agreed to in writing, software
+%%   distributed under the License is distributed on an "AS IS" BASIS,
+%%   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%   See the License for the specific language governing permissions and
+%%   limitations under the License.
+%%
+-module(cache_heap_SUITE).
+-include_lib("common_test/include/ct.hrl").
+
+%%
+%% common test
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+-compile(export_all).
+
+all() ->
+   [Test || {Test, NAry} <- ?MODULE:module_info(exports), 
+      Test =/= module_info,
+      Test =/= init_per_suite,
+      Test =/= end_per_suite,
+      NAry =:= 1
+   ].
+
+init_per_testcase(_, Config) ->
+   meck:new(cache_util, [passthrough]),
+   meck:expect(cache_util, now, fun() -> 0 end),
+   Config.
+
+end_per_testcase(_, _) ->
+   meck:unload(cache_util).
+
+%%
+heap_init(_) ->
+   {heap, set, 10, 6, 100, 1280, Segments} = cache_heap:new(set, 10, 60, 1000, 102400),
+   Expect = lists:seq(6, 60, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+% %%
+% heap_size(_) ->
+%    Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+%    10   = cache_heap:size(Heap).
+
+% %%
+% heap_heap(_) ->
+%    meck:new(cache_util, [passthrough]),
+%    meck:expect(cache_util, now, fun() -> 0 end),
+
+%    Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+%    {6, _} = cache_heap:head(Heap),
+
+%    meck:unload(cache_util).
+
+% %%
+% heap_tail(_) ->
+%    meck:new(cache_util, [passthrough]),
+%    meck:expect(cache_util, now, fun() -> 0 end),
+
+%    Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+%    Tail = cache_heap:tail(Heap),
+%    Expect = lists:seq(12, 60, 6),
+%    Expect = [Expire || {Expire, _} <- Tail],
+
+%    meck:unload(cache_util).
+
+%%
+heap_purge(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   {heap, set, 10, 6, 100, 1280, Segments} = cache_heap:purge(undefined, Heap),
+   Expect = lists:seq(6, 60, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+%%
+heap_slip_ok(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   {ok, Heap} = cache_heap:slip(undefined, Heap).
+
+%%
+heap_slip_ttl(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   meck:expect(cache_util, now, fun() -> 6 end),
+   {ttl,
+      {heap, set, 10, 6, 100, 1280, Segments}
+   } = cache_heap:slip(undefined, Heap),
+   Expect = lists:seq(12, 66, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+%%
+heap_split_last(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   {{60, _}, Segments} = cache_heap:split(Heap),
+   Expect = lists:seq(6, 54, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+%%
+heap_split_45(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   {{48, _}, Segments} = cache_heap:split(45, Heap),
+   Expect = lists:seq(6, 42, 6) ++ lists:seq(54, 60, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+%%
+heap_split_15(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   {{18, _}, Segments} = cache_heap:split(15, Heap),
+   Expect = lists:seq(6, 12, 6) ++ lists:seq(24, 60, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+%%
+heap_split_65(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   {{60, _}, Segments} = cache_heap:split(65, Heap),
+   Expect = lists:seq(6, 54, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+%%
+heap_split_0(_) ->
+   Heap = cache_heap:new(set, 10, 60, 1000, 102400),
+   {{6, _}, Segments} = cache_heap:split(0, Heap),
+   Expect = lists:seq(12, 60, 6),
+   Expect = [Expire || {Expire, _} <- queue:to_list(Segments)].
+
+

--- a/test/cache_shards_SUITE.erl
+++ b/test/cache_shards_SUITE.erl
@@ -17,6 +17,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile([export_all]).
+-compile(nowarn_export_all).
 
 all() ->
     [Test || {Test, NAry} <- ?MODULE:module_info(exports), 


### PR DESCRIPTION
__WHY__
Cache uses on-demand segment allocation. This technique benefits on short term by minimizing number of allocated ETS tables at application start. However, the heap management routines suffers from proper TTL eviction with this approach. Additionally, heap management used lists data structure to keep track of segments. 

closes #24 #23 

__WHAT__
* pre-allocate ETS segments at cache_start
* use FIFO queue for segment heap management -> O(1) vs O(n)
* add dedicated unit testing for heap management
* improve test coverage for cache interface